### PR TITLE
Fix LMST (dec deg)

### DIFF
--- a/stcalc/Program.cs
+++ b/stcalc/Program.cs
@@ -72,7 +72,7 @@ namespace stcalc
 
             Console.WriteLine("Greenwich Mean Sidereal Time (dec deg): " + ReduceAngle(theta0));
             Console.WriteLine("Greenwich Mean Sidereal Time (HMS):     " + gmstRA.ToString());
-            Console.WriteLine("Local Mean Sidereal Time (dec deg):     " + lmstRA.Hours);
+            Console.WriteLine("Local Mean Sidereal Time (dec deg):     " + lmstRA.ToDecimalDegrees());
             Console.WriteLine("Local Mean Sidereal Time (HMS):         " + lmstRA.ToString());
             Console.WriteLine(Environment.NewLine);
 


### PR DESCRIPTION
Was following along your article [here](https://squarewidget.com/astronomical-calculations-sidereal-time/), but in C. This screenshot here shows the LMST in decimal degrees as 7.5, which is simply the hour component of the final displayed LMST. I believe in decimal degrees it should be 112.97437, and the following change would fix that. Thanks for the great explanations, very helpful!

![](https://i0.wp.com/squarewidget.com/wp-content/uploads/2020/03/project-console-output.png?resize=840%2C466&ssl=1)